### PR TITLE
191457 Don't restart task when opening push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.0
 
-
+- [Breaking] For push opens don't set launch intent flags. Instead rely on the default React Native `singleTask` launch mode.
 - [Breaking] Changed the ```DeepLink``` object structure received from the DeepLinkHandler when calling ```Optimove.setDeepLinkHandler``` to:
 
 ```typescript

--- a/android/src/main/java/com/optimove/reactnative/PushReceiver.java
+++ b/android/src/main/java/com/optimove/reactnative/PushReceiver.java
@@ -40,7 +40,6 @@ public class PushReceiver extends PushBroadcastReceiver {
     }
 
     launchIntent.putExtra(PushMessage.EXTRAS_KEY, pushMessage);
-    launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
 
     return launchIntent;
   }

--- a/android/src/main/java/com/optimove/reactnative/PushReceiver.java
+++ b/android/src/main/java/com/optimove/reactnative/PushReceiver.java
@@ -31,6 +31,21 @@ public class PushReceiver extends PushBroadcastReceiver {
     PushReceiver.handlePushOpen(context, pushMessage, null);
   }
 
+  @Override
+  protected Intent getPushOpenActivityIntent(Context context, PushMessage pushMessage) {
+    Intent launchIntent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
+
+    if (null == launchIntent) {
+      return null;
+    }
+
+    launchIntent.putExtra(PushMessage.EXTRAS_KEY, pushMessage);
+    launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED);
+
+    return launchIntent;
+  }
+
+
   @SuppressWarnings("unchecked")
   public static void handlePushOpen(Context context, PushMessage pushMessage, String actionId) {
     PushReceiver pr = new PushReceiver();


### PR DESCRIPTION
### Description of Changes

Update launch intent flags for push notifications.

New task + reset if needed are default launcher flags  and mean that:

1. if activity doesn't exist, it's created
2. if it exists in any task anywhere in stack, task is brought to fg and activity put on top

### Breaking Changes

-   None

### Release Checklist

Bump versions in:

-   [x] package.json
-   [x] example/package.json
-   [x] android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java
-   [x] ios/OptimoveInitializer.swift
-   [x] CHANGELOG.md

Release:

-   [ ] Squash and merge to main
-   [ ] Delete branch once merged
-   [ ] ~Create tag from main matching chosen version~
-   [ ] Fill out release notes
-   [ ] ~Run `npm publish --access public`~

Holding for 2.0.0 release with other changes.
