### PR TITLE
191775 Support use_frameworks! option for iOS builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0
 
+- Support iOS projects with `use_frameworks!` enabled
 - [Breaking] For push opens don't set launch intent flags. Instead rely on the default React Native `singleTask` launch mode.
 - [Breaking] Changed the ```DeepLink``` object structure received from the DeepLinkHandler when calling ```Optimove.setDeepLinkHandler``` to:
 

--- a/ios/OptimoveReactNative.m
+++ b/ios/OptimoveReactNative.m
@@ -1,7 +1,12 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
+
+#if __has_include(<OptimoveReactNative/OptimoveReactNative-Swift.h>)
+#import <OptimoveReactNative/OptimoveReactNative-Swift.h>
+#elif __has_include("OptimoveReactNative-Swift.h")
 #import "OptimoveReactNative-Swift.h"
+#endif
 
 @interface RCT_EXTERN_MODULE(OptimoveReactNative, RCTEventEmitter)
 


### PR DESCRIPTION
### Reason for Changes

Fixes https://github.com/optimove-tech/Optimove-SDK-React-Native/issues/9 to enable use of `use_frameworks!` option for iOS builds.

### Description of Changes

If use_frameworks! is enabled, the header import style should be adapted in our native module sources.

Note that use_frameworks! is not the default configuration, and enabling frameworks for builds currently has some issues with various RN configurations & modules:

https://github.com/reactwg/react-native-new-architecture/discussions/115

To test at the moment, as well as enabling frameworks, Flipper must be disabled and linkage must be static (for Hermes). This may vary by RN version.

```rb
...
use_frameworks! :linkage => :static
...
    # Note that if you have use_frameworks! enabled, Flipper will not work and
    # you should disable the next line.
    :flipper_configuration => FlipperConfiguration.disabled,
...
```

### Breaking Changes

-   None

### Release Checklist

Bump versions in:

-   [ ] ~package.json~
-   [ ] ~example/package.json~
-   [ ] ~android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java~
-   [ ] ~ios/OptimoveInitializer.swift~
-   [x] CHANGELOG.md

Release:

-   [ ] Squash and merge to main
-   [ ] Delete branch once merged
-   [ ] ~Create tag from main matching chosen version~
-   [ ] Fill out release notes
-   [ ] ~Run `npm publish --access public`~

Holding for 2.0.0 release with other changes.

### Follow-ups

- Update wiki to remove showing `use_frameworks!`?
