### PR TITLE
Exported the matched and non matched resolution types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.3
+
+- Updated the DDL types to export the `MatchedResolution` and `NonMatchedResolution` types
+
 ## 2.0.2
 
 - Fixed the parsing of all in app related data passed from Android to React Native

--- a/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java
+++ b/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java
@@ -17,7 +17,7 @@ import org.json.JSONObject;
 
 public class OptimoveReactNativeInitializer {
 
-  private static final String SDK_VERSION = "2.0.2";
+  private static final String SDK_VERSION = "2.0.3";
   private static final int SDK_TYPE = 9;
   private static final int RUNTIME_TYPE = 7;
   private static final String RUNTIME_VERSION = "Unknown";

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "OptimoveReactNativeExample",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/ios/OptimoveInitializer.swift
+++ b/ios/OptimoveInitializer.swift
@@ -4,7 +4,7 @@ import OptimoveSDK
 @objc(OptimoveInitializer)
 class OptimoveInitializer: NSObject {
 
-    private static let sdkVersion = "2.0.2"
+    private static let sdkVersion = "2.0.3"
     private static let sdkType = 9
     private static let runtimeType = 7
     private static let runtimeVersion = "Unknown";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimove-inc/react-native",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Optimove React Native SDK",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/ddl.ts
+++ b/src/ddl.ts
@@ -3,12 +3,12 @@ export interface DeepLinkContent {
   description: string | null;
 }
 
-interface NonMatchedResolution {
+export interface NonMatchedResolution {
   resolution: Exclude<DeepLinkResolution, DeepLinkResolution.LINK_MATCHED>;
   url: string;
 }
 
-interface MatchedResolution {
+export interface MatchedResolution {
   resolution: DeepLinkResolution.LINK_MATCHED;
   url: string;
   content: DeepLinkContent;


### PR DESCRIPTION
### Description of Changes

Updated the DDL types to export the `MatchedResolution` and `NonMatchedResolution` types

### Breaking Changes

-   None

### Release Checklist

Bump versions in:

-   [x] package.json
-   [x] example/package.json
-   [x] android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java
-   [x] ios/OptimoveInitializer.swift
-   [x] CHANGELOG.md

Release:

-   [ ] Squash and merge to main
-   [ ] Delete branch once merged
-   [ ] Create tag from main matching chosen version
-   [ ] Fill out release notes
-   [ ] Run `npm publish --access public`
