### PR TITLE
AB#280182 - Pull in New Android Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.1
+
+- Android: updated Optimove Android SDK to `7.12.3`.
+
 ## 3.1.0
 
 - Added Embedded Messaging API (`embeddedMessagingGetMessages`, `embeddedMessagingSetAsRead`, `embeddedMessagingReportClickMetric`, `embeddedMessagingDeleteMessage`).

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ repositories {
 
 dependencies {
   implementation "com.facebook.react:react-android"
-  api 'com.optimove.android:optimove-android:7.11.1'
+  api 'com.optimove.android:optimove-android:7.12.3'
 }
 
 react {

--- a/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java
+++ b/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java
@@ -17,7 +17,7 @@ import org.json.JSONObject;
 
 public class OptimoveReactNativeInitializer {
 
-  private static final String SDK_VERSION = "3.1.0";
+  private static final String SDK_VERSION = "3.1.1";
   private static final int SDK_TYPE = 9;
   private static final int RUNTIME_TYPE = 7;
   private static final String RUNTIME_VERSION = "Unknown";

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "OptimoveReactNativeExample",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/ios/OptimoveInitializer.swift
+++ b/ios/OptimoveInitializer.swift
@@ -4,7 +4,7 @@ import OptimoveSDK
 @objc(OptimoveInitializer)
 public class OptimoveInitializer: NSObject {
 
-    private static let sdkVersion = "3.1.0"
+    private static let sdkVersion = "3.1.1"
     private static let sdkType = 9
     private static let runtimeType = 7
     private static let runtimeVersion = "Unknown";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimove-inc/react-native",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Optimove React Native SDK",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
### Description of Changes

Pulls in the latest Android release (`v7.12.3`), which hardened launch-intent resolution in `SessionHelper` and `PushBroadcastReceiver` with `try/catch`.

### Breaking Changes

-   None

### Release Checklist

Bump versions in:

-   [x] package.json
-   [x] example/package.json
-   [x] android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java
-   [x] ios/OptimoveInitializer.swift
-   [x] CHANGELOG.md

Release:

-   [x] Squash and merge to main
-   [x] Delete branch once merged
-   [x] Create tag from main matching chosen version
-   [x] Fill out release notes
-   [x] Run `npm publish --access public`
