### PR TITLE
AB#281037 - add gamifyWidgetOpen bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 3.2.0
 
 - Added `Optimove.gamifyWidgetOpen(widgetUrl, userId?, token?)` API to open the Gamify Widget bottom sheet.
-- Android: updated Optimove Android SDK to `7.13.1`.
+- Android: updated Optimove Android SDK to `7.14.0`.
 - iOS: Gamify Widget support requires upcoming iOS SDK release (podspec bump tracked separately).
 
 ## 3.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 3.2.0
 
-- Added `Optimove.gamifyWidgetOpen(widgetUrl, userId?, token?)` API to open the Gamify Widget bottom sheet.
+- Added `Optimove.gamifyWidgetOpen(widgetUrl, userId?, token?)` API to open the Gamify Widget.
 - Android: updated Optimove Android SDK to `7.14.0`.
-- iOS: Gamify Widget support requires upcoming iOS SDK release (podspec bump tracked separately).
+- iOS: TBD
 
 ## 3.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Added `Optimove.gamifyWidgetOpen(widgetUrl, userId?, token?)` API to open the Gamify Widget.
 - Android: updated Optimove Android SDK to `7.14.0`.
-- iOS: TBD
+- iOS: updated Optimove iOS SDK to `6.7.0`.
 
 ## 3.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.2.0
+
+- Added `Optimove.gamifyWidgetOpen(widgetUrl, userId?, token?)` API to open the Gamify Widget bottom sheet.
+- Android: updated Optimove Android SDK to `7.13.1`.
+- iOS: Gamify Widget support requires upcoming iOS SDK release (podspec bump tracked separately).
+
 ## 3.1.3
 
 - Android: updated Optimove Android SDK to `7.13.1`. This Android version reverts in-app deep-link handler storage to pre-7.8.1 behaviour: a direct strong reference on `OptimoveInApp`, with `setDeepLinkHandler(null)` to clear. Removes wrappers `LifecycleBoundDeepLinkHandler` and `WeakDeepLinkHandler`.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,6 +67,7 @@ repositories {
 dependencies {
   implementation "com.facebook.react:react-android"
   api 'com.optimove.android:optimove-android:7.13.1'
+  api 'com.optimove.android:gamify-widget-sdk:7.13.1'
 }
 
 react {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ repositories {
 
 dependencies {
   implementation "com.facebook.react:react-android"
-  api 'com.optimove.android:optimove-android:7.13.1'
+  api 'com.optimove.android:optimove-android:7.14.0'
 }
 
 react {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,7 +67,6 @@ repositories {
 dependencies {
   implementation "com.facebook.react:react-android"
   api 'com.optimove.android:optimove-android:7.13.1'
-  api 'com.optimove.android:gamify-widget-sdk:7.13.1'
 }
 
 react {

--- a/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java
+++ b/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java
@@ -17,7 +17,7 @@ import org.json.JSONObject;
 
 public class OptimoveReactNativeInitializer {
 
-  private static final String SDK_VERSION = "3.1.3";
+  private static final String SDK_VERSION = "3.2.0";
   private static final int SDK_TYPE = 9;
   private static final int RUNTIME_TYPE = 7;
   private static final String RUNTIME_VERSION = "Unknown";

--- a/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeModule.java
+++ b/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeModule.java
@@ -16,12 +16,15 @@ import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.module.annotations.ReactModule;
 import com.optimove.android.Optimove;
+import com.optimove.android.gamifywidgetsdk.GamifyWidgetSDK;
 import com.optimove.android.embeddedmessaging.Container;
 import com.optimove.android.embeddedmessaging.ContainerRequestOptions;
 import com.optimove.android.embeddedmessaging.EmbeddedMessage;
 import com.optimove.android.embeddedmessaging.OptimoveEmbeddedMessaging;
 import com.optimove.android.optimobile.InAppInboxItem;
 import com.optimove.android.optimobile.OptimoveInApp;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -260,6 +263,19 @@ public class OptimoveReactNativeModule extends NativeOptimoveReactNativeSpec {
       mapped.putInt("unreadCount", summary.getUnreadCount());
 
       promise.resolve(mapped);
+    });
+  }
+
+  @Override
+  public void gamifyWidgetOpen(String widgetUrl, @Nullable String userId, @Nullable String token) {
+    ReactApplicationContext ctx = getReactApplicationContext();
+    ctx.runOnUiQueueThread(() -> {
+      android.app.Activity activity = getCurrentActivity();
+      if (!(activity instanceof FragmentActivity)) {
+        return;
+      }
+      FragmentManager fm = ((FragmentActivity) activity).getSupportFragmentManager();
+      GamifyWidgetSDK.open(fm, widgetUrl, userId, token);
     });
   }
 

--- a/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeModule.java
+++ b/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeModule.java
@@ -275,7 +275,8 @@ public class OptimoveReactNativeModule extends NativeOptimoveReactNativeSpec {
         return;
       }
       FragmentManager fm = ((FragmentActivity) activity).getSupportFragmentManager();
-      GamifyWidgetSDK.open(fm, widgetUrl, userId, token);
+      GamifyWidgetSDK.init(widgetUrl);
+      GamifyWidgetSDK.open(fm, userId, token);
     });
   }
 

--- a/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeModule.java
+++ b/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeModule.java
@@ -23,8 +23,6 @@ import com.optimove.android.embeddedmessaging.EmbeddedMessage;
 import com.optimove.android.embeddedmessaging.OptimoveEmbeddedMessaging;
 import com.optimove.android.optimobile.InAppInboxItem;
 import com.optimove.android.optimobile.OptimoveInApp;
-import androidx.fragment.app.FragmentActivity;
-import androidx.fragment.app.FragmentManager;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -271,12 +269,11 @@ public class OptimoveReactNativeModule extends NativeOptimoveReactNativeSpec {
     ReactApplicationContext ctx = getReactApplicationContext();
     ctx.runOnUiQueueThread(() -> {
       android.app.Activity activity = getCurrentActivity();
-      if (!(activity instanceof FragmentActivity)) {
+      if (activity == null) {
         return;
       }
-      FragmentManager fm = ((FragmentActivity) activity).getSupportFragmentManager();
-      GamifyWidgetSDK.init(widgetUrl);
-      GamifyWidgetSDK.open(fm, userId, token);
+      GamifyWidgetSDK.initialize(widgetUrl);
+      GamifyWidgetSDK.getInstance().open(activity, userId, token);
     });
   }
 

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -32,5 +32,5 @@ target 'OptimoveReactNativeExample' do
 end
 
 target 'NotificationServiceExtension' do
-  pod 'OptimoveNotificationServiceExtension', '~> 6.4.1'
+  pod 'OptimoveNotificationServiceExtension', '~> 6.7.0'
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,12 +8,12 @@ PODS:
   - hermes-engine (0.76.9):
     - hermes-engine/Pre-built (= 0.76.9)
   - hermes-engine/Pre-built (0.76.9)
-  - optimove-react-native (3.1.0):
+  - optimove-react-native (3.2.0):
     - DoubleConversion
     - glog
     - hermes-engine
-    - OptimoveCore (~> 6.4.1)
-    - OptimoveSDK (~> 6.4.1)
+    - OptimoveCore (~> 6.7.0)
+    - OptimoveSDK (~> 6.7.0)
     - RCT-Folly (= 2024.10.14.00)
     - RCTRequired
     - RCTTypeSafety
@@ -31,10 +31,10 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - OptimoveCore (6.4.1)
-  - OptimoveNotificationServiceExtension (6.4.1)
-  - OptimoveSDK (6.4.1):
-    - OptimoveCore (= 6.4.1)
+  - OptimoveCore (6.7.0)
+  - OptimoveNotificationServiceExtension (6.7.0)
+  - OptimoveSDK (6.7.0):
+    - OptimoveCore (= 6.7.0)
   - RCT-Folly (2024.10.14.00):
     - boost
     - DoubleConversion
@@ -1313,7 +1313,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-pager-view (6.8.1):
+  - react-native-pager-view (6.9.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1672,7 +1672,7 @@ PODS:
     - React-logger
     - React-perflogger
     - React-utils (= 0.76.9)
-  - RNGestureHandler (2.27.1):
+  - RNGestureHandler (2.28.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1694,7 +1694,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.18.0):
+  - RNReanimated (3.19.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1716,10 +1716,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.18.0)
-    - RNReanimated/worklets (= 3.18.0)
+    - RNReanimated/reanimated (= 3.19.0)
+    - RNReanimated/worklets (= 3.19.0)
     - Yoga
-  - RNReanimated/reanimated (3.18.0):
+  - RNReanimated/reanimated (3.19.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1741,56 +1741,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.18.0)
+    - RNReanimated/reanimated/apple (= 3.19.0)
     - Yoga
-  - RNReanimated/reanimated/apple (3.18.0):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.10.14.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - RNReanimated/worklets (3.18.0):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.10.14.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - RNReanimated/worklets/apple (= 3.18.0)
-    - Yoga
-  - RNReanimated/worklets/apple (3.18.0):
+  - RNReanimated/reanimated/apple (3.19.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1813,7 +1766,54 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNScreens (4.12.0):
+  - RNReanimated/worklets (3.19.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.10.14.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNReanimated/worklets/apple (= 3.19.0)
+    - Yoga
+  - RNReanimated/worklets/apple (3.19.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.10.14.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - RNScreens (4.13.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1834,9 +1834,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.12.0)
+    - RNScreens/common (= 4.13.1)
     - Yoga
-  - RNScreens/common (4.12.0):
+  - RNScreens/common (4.13.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1870,7 +1870,7 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - optimove-react-native (from `../..`)
-  - OptimoveNotificationServiceExtension (~> 6.4.1)
+  - OptimoveNotificationServiceExtension (~> 6.7.0)
   - RCT-Folly (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec`)
   - RCTDeprecation (from `../node_modules/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation`)
@@ -2094,10 +2094,10 @@ SPEC CHECKSUMS:
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: 9e868dc7be781364296d6ee2f56d0c1a9ef0bb11
-  optimove-react-native: 361f48c50192644bd14994dd7a9658ffe24fa515
-  OptimoveCore: 8f9b76da066ddf8c2f9c5a6b62f7d9e1a1a3b74a
-  OptimoveNotificationServiceExtension: d162df1d1a0d4351e0deaa60f9f22650e7395d91
-  OptimoveSDK: 28c70f8ac8e4972dcff990485bdaa63c2db294fd
+  optimove-react-native: e056a5d8eb90e4d42693a43c7ae40d8a4c8175f7
+  OptimoveCore: 36cde1c2f281eaa1f7f076f9985734cbd216dc62
+  OptimoveNotificationServiceExtension: fdf2559a173ee7628425c3d509c5dab7b657123d
+  OptimoveSDK: ad669c18d3a3c36b8bc7d63827b96a38040dcf16
   RCT-Folly: 7b4f73a92ad9571b9dbdb05bb30fad927fa971e1
   RCTDeprecation: ebe712bb05077934b16c6bf25228bdec34b64f83
   RCTRequired: ca91e5dd26b64f577b528044c962baf171c6b716
@@ -2127,7 +2127,7 @@ SPEC CHECKSUMS:
   React-logger: dbca7bdfd4aa5ef69431362bde6b36d49403cb20
   React-Mapbuffer: 129fa9634f42d88a0c3761d2829db85175b985ee
   React-microtasksnativemodule: b5151a6d754fbf52292e758c4bb93b7c0d2f0b92
-  react-native-pager-view: 2bb68597caddbcab63664e7068027272fec0daac
+  react-native-pager-view: 913caecc365a7d5e9e65345fd64fd853de2e0227
   react-native-safe-area-context: 276e89d3c4f33b07a982e97638d2f67590010af3
   React-nativeconfig: 415626a63057638759bcc75e0a96e2e07771a479
   React-NativeModulesApple: bffc60f55895c2723b1e5472fa40567fe3df4923
@@ -2156,12 +2156,12 @@ SPEC CHECKSUMS:
   React-utils: 52cb73e127a39fc2d9f02f503b2a7b3b0abd23dd
   ReactCodegen: 31fcff227d0035956575be0c013a2edcc687a53c
   ReactCommon: 78c49c7cf7df16983ebc3c646b4f47398437f2ec
-  RNGestureHandler: cf9bafa43445416c1ce647f78de19c8ff63bc182
-  RNReanimated: 170d2f7655729d981001a9822efd545640bfb858
-  RNScreens: 1209becb8438a89b6e73162d7dcbe9842231aea0
+  RNGestureHandler: 77d8346a6a4e00617928cc8d0c0259fd03c1bf6a
+  RNReanimated: 56b6a2109020a02f908c8743d1108da85a450186
+  RNScreens: 76426ee25dbbefe9acee9f64bd9c22d2a5e3d68d
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 1259c7a8cbaccf7b4c3ddf8ee36ca11be9dee407
+  Yoga: 8a9b4a239337975815ff5f0430a9cbd5957d00fd
 
-PODFILE CHECKSUM: 9dbe32a3658b8d82a2e08104af2928c5e81327dc
+PODFILE CHECKSUM: e66cee1738ccc63ec89b642f61e48ffab73bcc08
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.14.2

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "OptimoveReactNativeExample",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,6 +1,7 @@
 import { Alert, NativeModules, Platform } from 'react-native';
 
 import { EmbeddedMessagingScreen } from './EmbeddedMessagingScreen';
+import { GamifyWidgetScreen } from './GamifyWidgetScreen';
 import { HomeScreen } from './HomeScreen';
 import { InboxScreen } from './InboxScreen';
 import { NavigationContainer } from '@react-navigation/native';
@@ -53,6 +54,20 @@ function App() {
           component={EmbeddedMessagingScreen}
           options={{
             title: 'Embedded Messaging',
+            headerStyle: {
+              backgroundColor: '#FF8566',
+            },
+            headerTintColor: '#fff',
+            headerTitleStyle: {
+              fontWeight: 'bold',
+            },
+          }}
+        />
+        <Stack.Screen
+          name="GamifyWidget"
+          component={GamifyWidgetScreen}
+          options={{
+            title: 'Gamify Widget',
             headerStyle: {
               backgroundColor: '#FF8566',
             },

--- a/example/src/GamifyWidgetScreen.tsx
+++ b/example/src/GamifyWidgetScreen.tsx
@@ -1,0 +1,173 @@
+import {
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useState } from 'react';
+
+import Optimove from '@optimove-inc/react-native';
+
+const Separator = () => <View style={styles.separator} />;
+
+type Env = 'Dev' | 'Prod US' | 'Prod EU';
+
+const BASE_URLS: Record<Env, string> = {
+  'Dev': 'https://opti-ls-widget-dev.optimove.net',
+  'Prod US': 'https://opti-ls-widget-us.optimove.net',
+  'Prod EU': 'https://opti-ls-widget-eu.optimove.net',
+};
+
+export function GamifyWidgetScreen() {
+  const [env, setEnv] = useState<Env>('Dev');
+  const [tenant, setTenant] = useState('');
+  const [userId, setUserId] = useState('');
+
+  const canOpen = tenant.trim() !== '' && userId.trim() !== '';
+
+  const openWidget = () => {
+    const widgetUrl = `${BASE_URLS[env]}/${encodeURIComponent(
+      tenant
+    )}/${encodeURIComponent(userId)}`;
+    Optimove.gamifyWidgetOpen(widgetUrl, userId);
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.container}>
+          <Text style={styles.titleText}>Environment</Text>
+          <Separator />
+          <View style={styles.envRow}>
+            {(Object.keys(BASE_URLS) as Env[]).map((e) => (
+              <TouchableOpacity
+                key={e}
+                style={[
+                  styles.envButton,
+                  env === e ? styles.envButtonActive : null,
+                ]}
+                onPress={() => setEnv(e)}
+              >
+                <Text
+                  style={[
+                    styles.envButtonText,
+                    env === e ? styles.envButtonTextActive : null,
+                  ]}
+                >
+                  {e}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+
+        <Separator />
+
+        <View style={styles.container}>
+          <Text style={styles.titleText}>Configuration</Text>
+          <Separator />
+          <TextInput
+            style={styles.input}
+            value={tenant}
+            onChangeText={setTenant}
+            placeholder="Tenant ID"
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+          <Separator />
+          <TextInput
+            style={styles.input}
+            value={userId}
+            onChangeText={setUserId}
+            placeholder="User ID"
+            autoCapitalize="none"
+            autoCorrect={false}
+          />
+        </View>
+
+        <Separator />
+
+        <View style={styles.container}>
+          <TouchableOpacity
+            style={[styles.button, canOpen ? null : styles.buttonDisabled]}
+            onPress={openWidget}
+            disabled={!canOpen}
+          >
+            <Text style={styles.buttonText}>Open Widget</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    paddingHorizontal: 16,
+  },
+  scrollContent: {
+    paddingVertical: 16,
+  },
+  container: {
+    width: '100%',
+    backgroundColor: '#A7B8CC',
+    padding: 10,
+    borderRadius: 4,
+  },
+  separator: {
+    marginVertical: 8,
+  },
+  titleText: {
+    fontSize: 12,
+    fontWeight: 'bold',
+  },
+  input: {
+    height: 40,
+    padding: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: '#FF8566',
+    backgroundColor: '#fff',
+  },
+  envRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  envButton: {
+    flex: 1,
+    marginHorizontal: 4,
+    paddingVertical: 8,
+    borderRadius: 4,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+  },
+  envButtonActive: {
+    backgroundColor: '#FF8566',
+  },
+  envButtonText: {
+    color: '#333',
+    fontWeight: 'bold',
+  },
+  envButtonTextActive: {
+    color: '#fff',
+  },
+  button: {
+    backgroundColor: '#FF8566',
+    padding: 10,
+    borderRadius: 4,
+    alignItems: 'center',
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  buttonText: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+});

--- a/example/src/HomeScreen.tsx
+++ b/example/src/HomeScreen.tsx
@@ -179,6 +179,13 @@ export function HomeScreen({ navigation }: { navigation: any }) {
           <Separator />
           <TouchableOpacity
             style={styles.button}
+            onPress={() => navigation.navigate('GamifyWidget')}
+          >
+            <Text style={styles.buttonText}>Gamify Widget</Text>
+          </TouchableOpacity>
+          <Separator />
+          <TouchableOpacity
+            style={styles.button}
             onPress={() => Optimove.inAppUpdateConsent(true)}
           >
             <Text style={styles.buttonText}>Opt in</Text>

--- a/example/src/HomeScreen.tsx
+++ b/example/src/HomeScreen.tsx
@@ -179,13 +179,6 @@ export function HomeScreen({ navigation }: { navigation: any }) {
           <Separator />
           <TouchableOpacity
             style={styles.button}
-            onPress={() => navigation.navigate('GamifyWidget')}
-          >
-            <Text style={styles.buttonText}>Gamify Widget</Text>
-          </TouchableOpacity>
-          <Separator />
-          <TouchableOpacity
-            style={styles.button}
             onPress={() => Optimove.inAppUpdateConsent(true)}
           >
             <Text style={styles.buttonText}>Opt in</Text>
@@ -196,6 +189,15 @@ export function HomeScreen({ navigation }: { navigation: any }) {
             onPress={() => Optimove.inAppUpdateConsent(false)}
           >
             <Text style={styles.buttonText}>Opt out</Text>
+          </TouchableOpacity>
+        </View>
+        <Separator />
+        <View style={styles.container}>
+          <TouchableOpacity
+            style={styles.button}
+            onPress={() => navigation.navigate('GamifyWidget')}
+          >
+            <Text style={styles.buttonText}>Gamify Widget</Text>
           </TouchableOpacity>
         </View>
       </ScrollView>

--- a/ios/OptimoveInitializer.swift
+++ b/ios/OptimoveInitializer.swift
@@ -4,7 +4,7 @@ import OptimoveSDK
 @objc(OptimoveInitializer)
 public class OptimoveInitializer: NSObject {
 
-    private static let sdkVersion = "3.1.3"
+    private static let sdkVersion = "3.2.0"
     private static let sdkType = 9
     private static let runtimeType = 7
     private static let runtimeVersion = "Unknown";

--- a/ios/OptimoveReactNative.mm
+++ b/ios/OptimoveReactNative.mm
@@ -53,6 +53,8 @@ RCT_EXTERN_METHOD(inAppMarkAllInboxItemsAsRead:(RCTPromiseResolveBlock)resolve r
 
 RCT_EXTERN_METHOD(inAppGetInboxSummary:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(gamifyWidgetOpen:(NSString*)widgetUrl userId:(NSString * _Nullable)userId token:(NSString * _Nullable)token)
+
 RCT_EXTERN_METHOD(embeddedMessagingGetMessages:(NSArray*)containers resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(embeddedMessagingDeleteMessage:(NSDictionary*)message resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)

--- a/ios/OptimoveReactNative.swift
+++ b/ios/OptimoveReactNative.swift
@@ -326,6 +326,12 @@ class OptimoveReactNative: RCTEventEmitter {
     }
 
     @objc
+    func gamifyWidgetOpen(_ widgetUrl: String, userId: String?, token: String?) {
+        // Gamify Widget SDK is not yet available on iOS.
+        print("[Optimove] gamifyWidgetOpen is not supported on iOS yet.")
+    }
+
+    @objc
     func inAppGetInboxSummary(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         OptimoveInApp.getInboxSummaryAsync(inboxSummaryBlock: { inAppInboxSummary in
             var inAppInboxSummaryMap = [String: Any?]()

--- a/ios/OptimoveReactNative.swift
+++ b/ios/OptimoveReactNative.swift
@@ -327,8 +327,11 @@ class OptimoveReactNative: RCTEventEmitter {
 
     @objc
     func gamifyWidgetOpen(_ widgetUrl: String, userId: String?, token: String?) {
-        // Gamify Widget SDK is not yet available on iOS.
-        print("[Optimove] gamifyWidgetOpen is not supported on iOS yet.")
+        DispatchQueue.main.async {
+            guard let vc = RCTPresentedViewController() else { return }
+            GamifyWidgetSDK.initialize(widgetUrl: widgetUrl)
+            GamifyWidgetSDK.open(from: vc, userId: userId, token: token)
+        }
     }
 
     @objc

--- a/optimove-react-native.podspec
+++ b/optimove-react-native.podspec
@@ -17,8 +17,8 @@ Pod::Spec.new do |s|
   s.swift_version = '5.0'
   s.public_header_files = []
 
-  s.dependency 'OptimoveCore', '~> 6.4.1'
-  s.dependency 'OptimoveSDK', '~> 6.4.1'
+  s.dependency 'OptimoveCore', '~> 6.7.0'
+  s.dependency 'OptimoveSDK', '~> 6.7.0'
 
   install_modules_dependencies(s)
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimove-inc/react-native",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "Optimove React Native SDK",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/src/NativeOptimoveReactNative.ts
+++ b/src/NativeOptimoveReactNative.ts
@@ -24,6 +24,12 @@ export interface Spec extends TurboModule {
   inAppMarkAllInboxItemsAsRead(): Promise<boolean>;
   inAppGetInboxSummary(): Promise<InAppInboxSummary>;
 
+  gamifyWidgetOpen(
+    widgetUrl: string,
+    userId: string | null,
+    token: string | null
+  ): void;
+
   embeddedMessagingGetMessages(containers: Object[]): Promise<Object>;
   embeddedMessagingDeleteMessage(message: Object): Promise<void>;
   embeddedMessagingReportClickMetric(message: Object): Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,18 @@ export default class Optimove {
     return OptimoveReactNative.inAppGetInboxSummary();
   }
 
+  static gamifyWidgetOpen(
+    widgetUrl: string,
+    userId?: string,
+    token?: string
+  ): void {
+    OptimoveReactNative.gamifyWidgetOpen(
+      widgetUrl,
+      userId ?? null,
+      token ?? null
+    );
+  }
+
   static embeddedMessagingGetMessages(
     containers: ContainerRequestOptions[]
   ): Promise<Record<string, Container>> {


### PR DESCRIPTION
<img width="474" height="864" alt="Screenshot 2026-05-29 at 15 23 17" src="https://github.com/user-attachments/assets/16e59384-52db-4222-af33-62d28405a2de" />
<img width="474" height="864" alt="Screenshot 2026-05-29 at 15 29 57" src="https://github.com/user-attachments/assets/ecf62a18-8fe6-4d94-b452-c39650fb014f" />

## Summary

- Bridges the Gamify Widget SDK to React Native via the existing TurboModule pattern
- Android: calls `GamifyWidgetSDK.initialize(url)` + `getInstance().open(activity, userId, token)` on the UI thread
- iOS: calls `GamifyWidgetSDK.initialize(widgetUrl:)` + `GamifyWidgetSDK.open(from:userId:token:)` on the main thread via `RCTPresentedViewController()`
- Bumps Android SDK to `7.14.0` and iOS SDK to `6.7.0` — the first releases bundling `GamifyWidgetSDK`

## Changes

| File | Change |
|---|---|
| `android/build.gradle` | Bump `optimove-android` to `7.14.0` |
| `optimove-react-native.podspec` | Bump `OptimoveCore` / `OptimoveSDK` to `~> 6.7.0` |
| `src/NativeOptimoveReactNative.ts` | Add `gamifyWidgetOpen` to `Spec` interface |
| `src/index.ts` | Add `static gamifyWidgetOpen(widgetUrl, userId?, token?)` facade |
| `android/.../OptimoveReactNativeModule.java` | `@Override gamifyWidgetOpen` — UI-thread dispatch, `initialize(url)` + `getInstance().open(activity, userId, token)` |
| `ios/OptimoveReactNative.swift` | Real implementation via `GamifyWidgetSDK` |
| `ios/OptimoveReactNative.mm` | `RCT_EXTERN_METHOD` declaration |
| `example/.../GamifyWidgetScreen.tsx` (+ `App.tsx`, `HomeScreen.tsx`, `ios/Podfile`) | Gamify test screen unified with the Android/iOS QA apps; example NSE pin → `6.7.0` |

## Usage

```typescript
// All params after widgetUrl are optional
Optimove.gamifyWidgetOpen('https://widget.example.com/path', userId, token);

// Without auth params
Optimove.gamifyWidgetOpen('https://widget.example.com/path');
```

## Test plan

- [x] Android: call `gamifyWidgetOpen` from example app — widget opens
- [x] Android: call without `userId`/`token` — widget opens without auth params
- [x] Android: close widget — dialog dismisses, app resumes without crash
- [ ] iOS: call `gamifyWidgetOpen` — widget opens

## Verification

**Android** — ran the example app on an emulator (Pixel 9 Pro, native SDK `7.14.0`, Dev env, tenant `60033`):
- App builds and runs against `optimove-android:7.14.0`
- `gamifyWidgetOpen(url, userId)` opens the full-screen WebView dialog and loads the widget
- `READY` → `INIT` handshake delivers the `userId` — confirmed by log `Optimove Gamify: sending INIT: {"type":"INIT","userId":"…"}` and the widget rendering `Player_<userId-suffix>`
- Closing dismisses the dialog; app resumes without crashing

**iOS** — `OptimoveSDK 6.7.0` resolves cleanly via `pod install`/`pod update` (lockfile pins `6.7.0`; `GamifyWidgetSDK` present in the integrated pod). The Swift bridge already matches the released `GamifyWidgetSDK.initialize(widgetUrl:)` + `open(from:userId:token:)` API.

## Notes

- **Android**: `GamifyWidgetSDK` ships in `optimove-android:7.14.0` (relocated from a never-published standalone module into `optimove-sdk` in optimove-tech/Optimove-SDK-Android#97). Public API is a singleton (`initialize(url)` + `getInstance().open(activity, userId, token)`), matching iOS/Web.
- **iOS**: `GamifyWidgetSDK` ships in `OptimoveSDK 6.7.0` (optimove-tech/Optimove-SDK-iOS#140, released 2026-06-01). Podspec pins bumped accordingly.
- Ticket: [AB#281037](https://mobius.visualstudio.com/7b12c5d6-c2cb-4957-9a09-46dfabf0bd18/_workitems/edit/281037)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
