### PR TITLE
AB#284758 Bump Android version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.3
+
+- Android: updated Optimove Android SDK to `7.13.1`
+
 ## 3.1.2
 
 - Android: updated Optimove Android SDK to `7.12.4`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.1.3
 
-- Android: updated Optimove Android SDK to `7.13.1`
+- Android: updated Optimove Android SDK to `7.13.1`. This Android version reverts in-app deep-link handler storage to pre-7.8.1 behaviour: a direct strong reference on `OptimoveInApp`, with `setDeepLinkHandler(null)` to clear. Removes wrappers `LifecycleBoundDeepLinkHandler` and `WeakDeepLinkHandler`.
 
 ## 3.1.2
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -66,7 +66,7 @@ repositories {
 
 dependencies {
   implementation "com.facebook.react:react-android"
-  api 'com.optimove.android:optimove-android:7.12.4'
+  api 'com.optimove.android:optimove-android:7.13.1'
 }
 
 react {

--- a/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java
+++ b/android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java
@@ -17,7 +17,7 @@ import org.json.JSONObject;
 
 public class OptimoveReactNativeInitializer {
 
-  private static final String SDK_VERSION = "3.1.2";
+  private static final String SDK_VERSION = "3.1.3";
   private static final int SDK_TYPE = 9;
   private static final int RUNTIME_TYPE = 7;
   private static final String RUNTIME_VERSION = "Unknown";

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "OptimoveReactNativeExample",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/ios/OptimoveInitializer.swift
+++ b/ios/OptimoveInitializer.swift
@@ -4,7 +4,7 @@ import OptimoveSDK
 @objc(OptimoveInitializer)
 public class OptimoveInitializer: NSObject {
 
-    private static let sdkVersion = "3.1.2"
+    private static let sdkVersion = "3.1.3"
     private static let sdkType = 9
     private static let runtimeType = 7
     private static let runtimeVersion = "Unknown";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@optimove-inc/react-native",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Optimove React Native SDK",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
### Description of Changes

- Bumps to new Android version; this Android version reverts in-app deep-link handler storage to pre-7.8.1 behaviour: a direct strong reference on `OptimoveInApp`, with `setDeepLinkHandler(null)` to clear. Removes wrappers `LifecycleBoundDeepLinkHandler` and `WeakDeepLinkHandler`.

### Breaking Changes

-   None

### Release Checklist

Bump versions in:

-   [x] package.json
-   [x] example/package.json
-   [x] android/src/main/java/com/optimove/reactnative/OptimoveReactNativeInitializer.java
-   [x] ios/OptimoveInitializer.swift
-   [x] CHANGELOG.md

Release:

-   [x] Squash and merge to main
-   [x] Delete branch once merged
-   [x] Create tag from main matching chosen version
-   [ ] Fill out release notes
-   [ ] Run `npm publish --access public`
